### PR TITLE
Release v3.0.0: Support PHP 8.3 & PHP 8.4, drop support of PHP 7.4 & PHP 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,27 +10,45 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: [ '8.1', '8.2', '8.3' ]
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # To avoid "Shallow clone detected" error in SonarCloud report
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v2
+      #~ PHP Setup
+      - name: Setup PHP ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@v2
         with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          php-version: ${{ matrix.php-versions }}
+
+      #~ Composer Cache
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-
+            ${{ runner.os }}-composer-
+
+      #~ Composer install
+      - name: Validate composer.json
+        run: composer validate
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: make install
+
+      #~ CI part
+      - name: Dependencies
+        run: make deps
 
       - name: Check Code Style
         run: make phpcs
@@ -43,17 +61,17 @@ jobs:
           sed -i 's+'$GITHUB_WORKSPACE'+/github/workspace+g' build/reports/phpunit/clover.xml
           sed -i 's+'$GITHUB_WORKSPACE'+/github/workspace+g' build/reports/phpunit/unit.xml
 
-      - name: PHP 7.4 Compatibility
-        run: make php74compatibility
+      - name: PHP min compatibility
+        run: make php-min-compatibility
 
-      - name: PHP 8.2 Compatibility
-        run: make php82compatibility
+      - name: PHP max compatibility
+        run: make php-max-compatibility
 
       - name: PHP Static Analyze
         run: make analyze
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v1.7
+        uses: SonarSource/sonarcloud-github-action@v2.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN:  ${{ secrets.SONAR_TOKEN }}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,24 @@
+<?php
+
+return (new PhpCsFixer\Config())
+    //~ Rules
+    ->setRules(
+        [
+            '@PER-CS2.0' => true,
+        ]
+    )
+
+    //~ Format
+    ->setFormat('txt')
+
+    //~ Cache
+    ->setUsingCache(true)
+    ->setCacheFile(__DIR__ . '/build/.php-cs-fixer.cache')
+
+    //~ Finder
+    ->setFinder((new PhpCsFixer\Finder())->in(
+        [
+            __DIR__ . '/src',
+            __DIR__ . '/tests',
+        ]))
+;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ```
 
 ----
+## [3.0.0] - 2024-08-22
+[3.0.0]: https://github.com/eureka-framework/component-curl/compare/2.2.0...3.0.0
+### Changed
+- Support PHP 8.3
+- Now use `\CurlHandle` as resource connection
+- Fix some code style
+- Replace PHPCS by php-cs-fixer
+- Move unit test to subdirectory `unit/`
+- Dev dependencies update
+- Update CI workflow
+- Update Makefile & Readme
+### Remove
+- Drop support of PHP 7.4 & PHP 8.0
+
+----
+
 ## [2.2.0] - 2023-03-10
 ### Changed
 - Support PHP 8.2

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,47 @@
-.PHONY: validate install update phpcs phpcbf php74compatibility php82compatibility phpstan analyze tests testdox ci clean
+.PHONY: validate install update phpcs phpcbf phpmincompatibility phpmaxcompatibility phpstan analyze tests testdox ci clean
+
+PHP_MIN_VERSION := "8.1"
+PHP_MAX_VERSION := "8.3"
+COMPOSER_BIN := composer
+
+ifneq (,$(wildcard ./.env))
+	include .env
+	export
+endif
 
 define header =
     @if [ -t 1 ]; then printf "\n\e[37m\e[100m  \e[104m $(1) \e[0m\n"; else printf "\n### $(1)\n"; fi
 endef
 
 #~ Composer dependency
+build: generator phpcsf
+
+generator:
+	$(call header,"Build new version of client, formatter & VO")
+	@./bin/script generator --file="./data/openapi.json" --debug
+
+#~ Composer dependency
 validate:
 	$(call header,Composer Validation)
-	@composer validate
+	@${COMPOSER_BIN} validate
 
 install:
 	$(call header,Composer Install)
-	@composer install
+	@${COMPOSER_BIN} install
 
 update:
 	$(call header,Composer Update)
-	@composer update
+	@${COMPOSER_BIN} update
+	@${COMPOSER_BIN} bump --dev-only
+
+outdated:
+	$(call header,Composer Outdated)
+	@${COMPOSER_BIN} outdated --direct
 
 composer.lock: install
 
 #~ Vendor binaries dependencies
-vendor/bin/phpcbf:
-vendor/bin/phpcs:
+vendor/bin/php-cs-fixer:
 vendor/bin/phpstan:
 vendor/bin/phpunit:
 
@@ -29,47 +49,53 @@ vendor/bin/phpunit:
 build/reports/phpunit:
 	@mkdir -p build/reports/phpunit
 
-build/reports/phpcs:
-	@mkdir -p build/reports/cs
-
 build/reports/phpstan:
 	@mkdir -p build/reports/phpstan
 
 #~ main commands
-phpcs: vendor/bin/phpcs build/reports/phpcs
+deps: composer.json # jenkins + manual
+	$(call header,Checking Dependencies)
+	@XDEBUG_MODE=off ./vendor/bin/composer-dependency-analyser --config=./ci/composer-dependency-analyser.php # for shadow & unused required dependencies
+	#@XDEBUG_MODE=off ./vendor/bin/composer-require-checker check # mainly for ext-* missing dependencies
+
+phpcs: vendor/bin/php-cs-fixer # jenkins + manual
 	$(call header,Checking Code Style)
-	@./vendor/bin/phpcs --standard=./ci/phpcs/eureka.xml --cache=./build/cs_eureka.cache -p --report-full --report-checkstyle=./build/reports/cs/eureka.xml src/ tests/
+	@XDEBUG_MODE=off ./vendor/bin/php-cs-fixer check -v --diff
 
-phpcbf: vendor/bin/phpcbf
+phpcsf: vendor/bin/php-cs-fixer # manual
 	$(call header,Fixing Code Style)
-	@./vendor/bin/phpcbf --standard=./ci/phpcs/eureka.xml src/ tests/
+	@XDEBUG_MODE=off ./vendor/bin/php-cs-fixer fix -v
 
-php74compatibility: vendor/bin/phpstan build/reports/phpstan
-	$(call header,Checking PHP 7.4 compatibility)
-	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/php74-compatibility.neon --error-format=table
+php-min-compatibility: vendor/bin/phpstan build/reports/phpstan # jenkins + manual
+	$(call header,Checking PHP $(PHP_MIN_VERSION) compatibility)
+	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/php-min-compatibility.neon --error-format=table
 
-php82compatibility: vendor/bin/phpstan build/reports/phpstan
-	$(call header,Checking PHP 8.1 compatibility)
-	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/php82-compatibility.neon --error-format=table
+php-max-compatibility: vendor/bin/phpstan build/reports/phpstan # jenkins + manual
+	$(call header,Checking PHP $(PHP_MAX_VERSION) compatibility)
+	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/php-max-compatibility.neon --error-format=table
 
-analyze: vendor/bin/phpstan build/reports/phpstan
-	$(call header,Running Static Analyze - Pretty tty format)
-	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --error-format=table
-
-phpstan: vendor/bin/phpstan build/reports/phpstan
+phpstan: vendor/bin/phpstan build/reports/phpstan # jenkins
 	$(call header,Running Static Analyze)
 	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --error-format=checkstyle > ./build/reports/phpstan/phpstan.xml
 
-tests: vendor/bin/phpunit build/reports/phpunit
+analyze: vendor/bin/phpstan build/reports/phpstan # manual
+	$(call header,Running Static Analyze - Pretty tty format)
+	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --error-format=table
+
+tests: vendor/bin/phpunit build/reports/phpunit # jenkins + manual
 	$(call header,Running Unit Tests)
-	@XDEBUG_MODE=coverage php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-clover=./build/reports/phpunit/clover.xml --log-junit=./build/reports/phpunit/unit.xml --coverage-php=./build/reports/phpunit/unit.cov --coverage-html=./build/reports/coverage/ --fail-on-warning
+	@XDEBUG_MODE=coverage php -dzend_extension=xdebug.so ./vendor/bin/phpunit --testsuite=unit --coverage-clover=./build/reports/phpunit/clover.xml --log-junit=./build/reports/phpunit/unit.xml --coverage-php=./build/reports/phpunit/unit.cov --coverage-html=./build/reports/coverage/ --fail-on-warning
 
-testdox: vendor/bin/phpunit $(PHP_FILES)
+integration: vendor/bin/phpunit build/reports/phpunit # manual
+	$(call header,Running Integration Tests)
+	@XDEBUG_MODE=coverage php -dzend_extension=xdebug.so ./vendor/bin/phpunit --testsuite=integration --fail-on-warning
+
+testdox: vendor/bin/phpunit # manual
 	$(call header,Running Unit Tests (Pretty format))
-	@XDEBUG_MODE=coverage php -dzend_extension=xdebug.so ./vendor/bin/phpunit --fail-on-warning --testdox
+	@XDEBUG_MODE=coverage php -dzend_extension=xdebug.so ./vendor/bin/phpunit --testsuite=unit --fail-on-warning --testdox
 
-clean:
+clean: # manual
 	$(call header,Cleaning previous build)
 	@if [ "$(shell ls -A ./build)" ]; then rm -rf ./build/*; fi; echo " done"
 
-ci: clean validate install phpcs tests php74compatibility php82compatibility analyze
+ci: clean validate deps phpcs tests php-min-compatibility php-max-compatibility analyze

--- a/README.md
+++ b/README.md
@@ -6,29 +6,98 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=eureka-framework_component-curl&metric=alert_status)](https://sonarcloud.io/dashboard?id=eureka-framework_component-curl)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=eureka-framework_component-curl&metric=coverage)](https://sonarcloud.io/dashboard?id=eureka-framework_component-curl)
 
+## Why?
+
 Component Curl &amp; Http Client PSR implementation.
 
 
 ## Installation
 
-You can install the component (for testing) with the following command:
+If you wish to install it in your project, require it via composer:
+
+```bash
+composer require eureka/component-curl
+```
+
+
+## Usage
+
+TODO
+
+
+
+
+## Contributing
+
+See the [CONTRIBUTING](CONTRIBUTING.md) file.
+
+
+### Install / update project
+
+You can install project with the following command:
 ```bash
 make install
 ```
 
-## Update
-
-You can update the component (for testing) with the following command:
+And update with the following command:
 ```bash
 make update
 ```
 
+NB: For the components, the `composer.lock` file is not committed.
 
-## Testing
+### Testing & CI (Continuous Integration)
 
-You can test the component with the following commands:
+#### Tests
+You can run tests (with coverage) on your side with following command:
+```bash
+make tests
+```
+
+You can run tests (with coverage) on your side with following command:
+```bash
+make integration
+```
+
+For prettier output (but without coverage), you can use the following command:
+```bash
+make testdox # run tests without coverage reports but with prettified output
+```
+
+#### Code Style
+You also can run code style check with following commands:
 ```bash
 make phpcs
-make tests
-make testdox
 ```
+
+You also can run code style fixes with following commands:
+```bash
+make phpcsf
+```
+
+#### Static Analysis
+To perform a static analyze of your code (with phpstan, lvl 9 at default), you can use the following command:
+```bash
+make analyze
+```
+
+Minimal supported version:
+```bash
+make php-min-compatibility
+```
+
+Maximal supported version:
+```bash
+make php-max-compatibility
+```
+
+#### CI Simulation
+And the last "helper" commands, you can run before commit and push, is:
+```bash
+make ci  
+```
+
+
+## License
+
+This project is licensed under the MIT License - see the `LICENSE` file for details

--- a/ci/composer-dependency-analyser.php
+++ b/ci/composer-dependency-analyser.php
@@ -1,0 +1,10 @@
+<?php
+
+use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+
+$config = new Configuration();
+
+return $config
+    ->addPathToScan(__DIR__ . '/../src', isDev: false)
+    ->addPathToScan(__DIR__ . '/../tests', isDev: true)
+;

--- a/ci/php-max-compatibility.neon
+++ b/ci/php-max-compatibility.neon
@@ -1,0 +1,10 @@
+includes:
+  - ./../vendor/phpstan/phpstan-phpunit/extension.neon
+  - ./../vendor/phpstan/phpstan-phpunit/rules.neon
+
+parameters:
+  phpVersion: 80300
+  level: 0
+  paths:
+    - ./../src
+    - ./../tests

--- a/ci/php-min-compatibility.neon
+++ b/ci/php-min-compatibility.neon
@@ -1,0 +1,10 @@
+includes:
+  - ./../vendor/phpstan/phpstan-phpunit/extension.neon
+  - ./../vendor/phpstan/phpstan-phpunit/rules.neon
+
+parameters:
+  phpVersion: 80100
+  level: 0
+  paths:
+    - ./../src
+    - ./../tests

--- a/ci/php74-compatibility.neon
+++ b/ci/php74-compatibility.neon
@@ -1,9 +1,0 @@
-parameters:
-  phpVersion: 70400 # PHP 7.4
-  level: 0
-  paths:
-    - ./../src
-    - ./../tests
-
-  bootstrapFiles:
-    - ./../vendor/autoload.php

--- a/ci/php82-compatibility.neon
+++ b/ci/php82-compatibility.neon
@@ -1,9 +1,0 @@
-parameters:
-  phpVersion: 80200 # PHP 8.2
-  level: 0
-  paths:
-    - ./../src
-    - ./../tests
-
-  bootstrapFiles:
-    - ./../vendor/autoload.php

--- a/ci/phpcs/eureka.xml
+++ b/ci/phpcs/eureka.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<ruleset name="eureka">
-    <description>The coding standard for Eureka.</description>
-
-    <arg value="nps"/>
-
-    <rule ref="PSR12"/>
-</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -19,32 +19,33 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Eureka\\Component\\Curl\\Tests\\": "./tests"
+      "Eureka\\Component\\Curl\\Tests\\Unit\\": "./tests/unit",
+      "Eureka\\Component\\Curl\\Tests\\Integration\\": "./tests/integration"
     }
   },
 
   "config": {
-    "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
-    }
+    "sort-packages": true
   },
 
   "require": {
-    "php": "7.4.*||8.0.*||8.1.*||8.2.*",
+    "php": "8.1.*||8.2.*||8.3.*||8.4.*",
     "ext-curl": "*",
     "ext-json": "*",
 
     "nyholm/psr7": "^1.5",
 
     "psr/http-client": "^1.0",
-    "psr/http-factory": "^1.0"
+    "psr/http-message": "^1.0||^2.0"
   },
 
   "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-    "phpstan/phpstan": "^1.10",
-    "phpunit/phpcov": "^8.2",
-    "phpunit/phpunit": "^9.6",
-    "squizlabs/php_codesniffer": "^3.7"
+    "friendsofphp/php-cs-fixer": "^3.62.0",
+    "maglnet/composer-require-checker": "^4.7.1",
+    "phpstan/phpstan": "^1.11.11",
+    "phpstan/phpstan-phpunit": "^1.4.0",
+    "phpunit/phpcov": "^9.0.2",
+    "phpunit/phpunit": "^10.5.30",
+    "shipmonk/composer-dependency-analyser": "^1.7.0"
   }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,9 @@
+includes:
+  - ./vendor/phpstan/phpstan-phpunit/extension.neon
+  - ./vendor/phpstan/phpstan-phpunit/rules.neon
+
 parameters:
-  phpVersion: 70400 # PHP 7.4 - Current minimal version supported
+  phpVersion: 80100 # PHP 8.1 - Current minimal version supported
   level: max
   paths:
     - ./src

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,34 +1,22 @@
 <?xml version="1.0"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-        backupGlobals="true"
-        backupStaticAttributes="false"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
         colors="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        forceCoversAnnotation="false"
-        processIsolation="false"
-        stopOnError="false"
-        stopOnFailure="false"
-        stopOnIncomplete="false"
-        stopOnSkipped="false"
-        stopOnRisky="false"
-        timeoutForSmallTests="1"
-        timeoutForMediumTests="10"
-        timeoutForLargeTests="60"
-        verbose="false">
-
-  <coverage>
+        cacheDirectory="build/.phpunit.cache"
+>
+  <source>
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+  </source>
 
   <testsuites>
-    <testsuite name="Test suite">
-      <directory>./tests</directory>
+    <testsuite name="unit">
+      <directory>./tests/unit</directory>
+    </testsuite>
+    <testsuite name="integration">
+      <directory>./tests/integration</directory>
     </testsuite>
   </testsuites>
 

--- a/src/Curl.php
+++ b/src/Curl.php
@@ -20,10 +20,8 @@ use Eureka\Component\Curl\Exception\CurlInitException;
  */
 class Curl
 {
-    /** @var resource|null $connection Curl connection resource */
-    protected /*?\CurlHandle*/ $connection = null;
+    protected \CurlHandle|null $connection = null;
 
-    /** @var string|null $message Message data */
     protected ?string $message = null;
 
     /** @var array<string[][]|float|int|string|null> $curlInfo Curl info data */
@@ -88,7 +86,7 @@ class Curl
      *
      * @codeCoverageIgnore
      */
-    public function exec()
+    public function exec(): bool|string
     {
         $result = curl_exec($this->getConnection());
         $info   = curl_getinfo($this->getConnection());
@@ -186,19 +184,19 @@ class Curl
             return false;
         }
 
-        return (empty($this->message));
+        return empty($this->message);
     }
 
     /**
      * Override default option (array or name/value)
      *
      * @param array<mixed>|string $name Name or array of options to set.
-     * @param mixed $value Value to set.
+     * @param mixed|null $value Value to set.
      * @return $this
      *
      * @codeCoverageIgnore
      */
-    public function setOptionDefault($name, $value = null): self
+    public function setOptionDefault(array|string $name, mixed $value = null): self
     {
         if (is_array($name)) {
             $this->defaultOptions = $name + $this->defaultOptions;
@@ -213,14 +211,14 @@ class Curl
      * Set option (array or name/value)
      *
      * @param array<mixed>|int $name Name or array of options to set.
-     * @param mixed $value Value to set.
+     * @param mixed|null $value Value to set.
      * @return $this
      * @throws Exception\CurlOptionException
      * @throws Exception\CurlInitException
      *
      * @codeCoverageIgnore
      */
-    public function setOption($name, $value = null): self
+    public function setOption(array|int $name, mixed $value = null): self
     {
         if (is_array($name)) {
             return $this->setOptions($name);
@@ -271,7 +269,7 @@ class Curl
      *
      * @codeCoverageIgnore
      */
-    public function setPostData($data): self
+    public function setPostData(array|string $data): self
     {
         return $this->setOption(CURLOPT_POSTFIELDS, $data);
     }
@@ -348,7 +346,7 @@ class Curl
                 break;
             default:
                 throw new Exception\CurlUnexpectedValueException(
-                    "Set method failed: method $method is not supported"
+                    "Set method failed: method $method is not supported",
                 );
         }
 
@@ -356,10 +354,10 @@ class Curl
     }
 
     /**
-     * @return resource
+     * @return \CurlHandle
      * @throws CurlInitException
      */
-    private function getConnection()
+    private function getConnection(): \CurlHandle
     {
         if (empty($this->connection)) {
             throw new CurlInitException('Curl connection has not be initialized or initialization failed!');

--- a/src/Exception/CurlException.php
+++ b/src/Exception/CurlException.php
@@ -16,6 +16,4 @@ namespace Eureka\Component\Curl\Exception;
  *
  * @author Romain Cottard
  */
-class CurlException extends \Exception
-{
-}
+class CurlException extends \Exception {}

--- a/src/Exception/CurlExecException.php
+++ b/src/Exception/CurlExecException.php
@@ -16,6 +16,4 @@ namespace Eureka\Component\Curl\Exception;
  *
  * @author Romain Cottard
  */
-class CurlExecException extends CurlException
-{
-}
+class CurlExecException extends CurlException {}

--- a/src/Exception/CurlInitException.php
+++ b/src/Exception/CurlInitException.php
@@ -16,6 +16,4 @@ namespace Eureka\Component\Curl\Exception;
  *
  * @author Romain Cottard
  */
-class CurlInitException extends CurlException
-{
-}
+class CurlInitException extends CurlException {}

--- a/src/Exception/CurlOptionException.php
+++ b/src/Exception/CurlOptionException.php
@@ -16,6 +16,4 @@ namespace Eureka\Component\Curl\Exception;
  *
  * @author Romain Cottard
  */
-class CurlOptionException extends CurlException
-{
-}
+class CurlOptionException extends CurlException {}

--- a/src/Exception/CurlUnexpectedValueException.php
+++ b/src/Exception/CurlUnexpectedValueException.php
@@ -16,6 +16,4 @@ namespace Eureka\Component\Curl\Exception;
  *
  * @author Romain Cottard
  */
-class CurlUnexpectedValueException extends CurlException
-{
-}
+class CurlUnexpectedValueException extends CurlException {}

--- a/src/Exception/HttpClientException.php
+++ b/src/Exception/HttpClientException.php
@@ -18,6 +18,4 @@ use Psr\Http\Client\ClientExceptionInterface;
  *
  * @author Romain Cottard
  */
-class HttpClientException extends \Exception implements ClientExceptionInterface
-{
-}
+class HttpClientException extends \Exception implements ClientExceptionInterface {}

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -44,7 +44,7 @@ class HttpClient implements ClientInterface
     public function __construct(
         int $timeout = 3,
         int $connectTimeout = 1,
-        string $userAgent = self::USER_AGENT_BROWSER_FIREFOX
+        string $userAgent = self::USER_AGENT_BROWSER_FIREFOX,
     ) {
         $this->timeout        = $timeout;
         $this->connectTimeout = $connectTimeout;
@@ -67,7 +67,7 @@ class HttpClient implements ClientInterface
     public function sendRequest(
         RequestInterface $request,
         int $connectTimeout = 30,
-        int $timeout = 60
+        int $timeout = 60,
     ): ResponseInterface {
         try {
             $streamResource = fopen('php://temp', 'w+');
@@ -99,9 +99,9 @@ class HttpClient implements ClientInterface
                         'Execution failed ! (error: %s, code: %d, infos: %s)',
                         $error,
                         $errno,
-                        json_encode($curl->getInfo())
+                        json_encode($curl->getInfo()),
                     ),
-                    $errno
+                    $errno,
                 );
             }
 

--- a/tests/unit/CurlTest.php
+++ b/tests/unit/CurlTest.php
@@ -9,10 +9,9 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Curl\Tests;
+namespace Eureka\Component\Curl\Tests\Unit;
 
 use Eureka\Component\Curl\Curl;
-use Eureka\Component\Curl\Exception\CurlInitException;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/unit/HttpClientTest.php
+++ b/tests/unit/HttpClientTest.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Curl\Tests;
+namespace Eureka\Component\Curl\Tests\Unit;
 
 use Eureka\Component\Curl\HttpClient;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
- Add Support PHP 8.3 & PHP 8.4
- Drop support of PHP 7.4 & PHP 8.0
- Now use `\CurlHandle` as resource connection
- Fix some code style
- Replace PHPCS by php-cs-fixer
- Move unit test to subdirectory `unit/`
- Dev dependencies update
- Update CI workflow
- Update Makefile & Readme