### PR TITLE
Component Curl upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.1', '8.2', '8.3', '8.4' ]
+        php-versions: [ '8.3', '8.4', '8.5' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,10 +15,10 @@ jobs:
           fetch-depth: 0 # To avoid "Shallow clone detected" error in SonarCloud report
 
       #~ PHP Setup
-      - name: Setup PHP 8.1 # Minimum version
+      - name: Setup PHP 8.3 # Minimum version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
 
       #~ Composer Cache
       - name: Get Composer Cache Directory
@@ -41,6 +41,6 @@ jobs:
         run: make php/tests # To generate the coverage report
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v5.2.0
+        uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,7 +4,7 @@ return (new PhpCsFixer\Config())
     //~ Rules
     ->setRules(
         [
-            '@PER-CS2.0' => true,
+            '@PER-CS3x0' => true,
         ]
     )
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ```
 
 ----
+## [4.0.0] - 2025-12-24
+[4.0.0]: https://github.com/eureka-framework/component-curl/compare/3.1.0...4.0.0
+### Added
+- Add PHP 8.5 support
+### Removed
+- Drop PHP 7.4 support
+- Drop PHP 8.1 support
+- Drop PHP 8.2 support
+### Changed
+- Use PER Code Style 3.0
+- Update CI config
+- Deprecated usage for Curl::close() (no effect since PHP 8.0)
+
+----
 ## [3.1.0] - 2025-05-16
 [3.1.0]: https://github.com/eureka-framework/component-curl/compare/3.0.0...3.1.0
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: validate install update php/deps php/check php/fix php/min-compatibility php/max-compatibility php/phpstan php/analyze php/tests php/test php/testdox ci clean
 
+PHP_MIN_VERSION := "8.3"
+PHP_MAX_VERSION := "8.5"
 COMPOSER_BIN := composer
 define header =
     @if [ -t 1 ]; then printf "\n\e[37m\e[100m  \e[104m $(1) \e[0m\n"; else printf "\n### $(1)\n"; fi
@@ -40,17 +42,17 @@ php/deps: composer.json
 
 php/check: vendor/bin/php-cs-fixer
 	$(call header,Checking Code Style)
-	@PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer check
+	@XDEBUG_MODE=off ./vendor/bin/php-cs-fixer check
 php/fix: vendor/bin/php-cs-fixer
 	$(call header,Fixing Code Style)
-	@PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix -v
+	@XDEBUG_MODE=off ./vendor/bin/php-cs-fixer fix -v
 
 php/min-compatibility: vendor/bin/phpstan build/reports/phpstan
-	$(call header,Checking PHP 8.1 compatibility)
+	$(call header,Checking PHP ${PHP_MIN_VERSION} compatibility)
 	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/phpmin-compatibility.neon --error-format=table
 
 php/max-compatibility: vendor/bin/phpstan build/reports/phpstan #ci
-	$(call header,Checking PHP 8.4 compatibility)
+	$(call header,Checking PHP ${PHP_MAX_VERSION} compatibility)
 	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/phpmax-compatibility.neon --error-format=table
 
 php/analyze: vendor/bin/phpstan build/reports/phpstan #manual & ci

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # component-curl
 
 [![Current version](https://img.shields.io/packagist/v/eureka/component-curl.svg?logo=composer)](https://packagist.org/packages/eureka/component-curl)
-[![Supported PHP version](https://img.shields.io/static/v1?logo=php&label=PHP&message=8.1%20-%208.4a&color=777bb4)](https://packagist.org/packages/eureka/component-curl)
+[![Supported PHP version](https://img.shields.io/static/v1?logo=php&label=PHP&message=8.3%20-%208.5&color=777bb4)](https://packagist.org/packages/eureka/component-curl)
 ![CI](https://github.com/eureka-framework/component-curl/workflows/CI/badge.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=eureka-framework_component-curl&metric=alert_status)](https://sonarcloud.io/dashboard?id=eureka-framework_component-curl)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=eureka-framework_component-curl&metric=coverage)](https://sonarcloud.io/dashboard?id=eureka-framework_component-curl)

--- a/ci/composer-dependency-analyser.php
+++ b/ci/composer-dependency-analyser.php
@@ -7,4 +7,5 @@ $config = new Configuration();
 return $config
     ->addPathToScan(__DIR__ . '/../src', isDev: false)
     ->addPathToScan(__DIR__ . '/../tests', isDev: true)
+    ->addPathToScan(__DIR__ . '/../tests', isDev: true)
 ;

--- a/ci/phpmax-compatibility.neon
+++ b/ci/phpmax-compatibility.neon
@@ -3,7 +3,7 @@ includes:
   - ./../vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
-  phpVersion: 80400
+  phpVersion: 80500
   level: 0
   paths:
     - ./../src

--- a/ci/phpmin-compatibility.neon
+++ b/ci/phpmin-compatibility.neon
@@ -3,7 +3,7 @@ includes:
   - ./../vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
-  phpVersion: 80100
+  phpVersion: 80300
   level: 0
   paths:
     - ./../src

--- a/composer.json
+++ b/composer.json
@@ -29,22 +29,23 @@
   },
 
   "require": {
-    "php": "8.1.*||8.2.*||8.3.*||8.4.*",
+    "php": ">=8.3",
     "ext-curl": "*",
     "ext-json": "*",
 
-    "nyholm/psr7": "^1.5",
+    "nyholm/psr7": "^1.0",
 
     "psr/http-client": "^1.0",
-    "psr/http-message": "^1.0||^2.0"
+    "psr/http-message": "^1.0||^2.0",
+    "symfony/polyfill-php84": "^1.0"
   },
 
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.75.0",
-    "phpstan/phpstan": "^2.1.16",
-    "phpstan/phpstan-phpunit": "^2.0.6",
-    "phpunit/phpcov": "^9.0.2",
-    "phpunit/phpunit": "^10.5.46",
-    "shipmonk/composer-dependency-analyser": "^1.8.3"
+    "friendsofphp/php-cs-fixer": "^3.92.3",
+    "phpstan/phpstan": "^2.1.33",
+    "phpstan/phpstan-phpunit": "^2.0.11",
+    "phpunit/phpcov": "^11.0.3",
+    "phpunit/phpunit": "^12.5.4",
+    "shipmonk/composer-dependency-analyser": "^1.8.4"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
     "nyholm/psr7": "^1.0",
 
     "psr/http-client": "^1.0",
-    "psr/http-message": "^1.0||^2.0",
-    "symfony/polyfill-php84": "^1.0"
+    "psr/http-message": "^1.0||^2.0"
   },
 
   "require-dev": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,7 +3,7 @@ includes:
   - ./vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
-  phpVersion: 80100 # PHP 8.1 - Current minimal version supported
+  phpVersion: 80300
   level: max
   paths:
     - ./src

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,7 @@
         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
         colors="true"
         cacheDirectory="build/.phpunit.cache"
+        displayDetailsOnTestsThatTriggerDeprecations="true"
 >
   <source>
     <include>

--- a/src/Curl.php
+++ b/src/Curl.php
@@ -64,9 +64,8 @@ class Curl
     /**
      * Close connection.
      *
-     * @return $this
+     * @deprecated
      */
-    #[\Deprecated]
     public function close(): self
     {
         return $this;

--- a/src/Curl.php
+++ b/src/Curl.php
@@ -20,7 +20,7 @@ use Eureka\Component\Curl\Exception\CurlInitException;
  */
 class Curl
 {
-    protected \CurlHandle|null $connection = null;
+    protected ?\CurlHandle $connection = null;
 
     protected ?string $message = null;
 
@@ -36,7 +36,7 @@ class Curl
      * @param null|string $url
      * @throws Exception\CurlInitException
      */
-    public function __construct(string|null $url = null)
+    public function __construct(?string $url = null)
     {
         $this->init($url);
     }
@@ -48,7 +48,7 @@ class Curl
      * @return $this
      * @throws CurlInitException
      */
-    public function init(string|null $url = null): self
+    public function init(?string $url = null): self
     {
         $connection = empty($url) ? curl_init() : curl_init($url);
 
@@ -65,12 +65,10 @@ class Curl
      * Close connection.
      *
      * @return $this
-     * @throws CurlInitException
      */
+    #[\Deprecated]
     public function close(): self
     {
-        curl_close($this->getConnection());
-
         return $this;
     }
 
@@ -221,7 +219,6 @@ class Curl
         if (false === curl_setopt($this->getConnection(), $name, $value)) {
             $error = $this->getError();
             $errno = $this->getErrorNumber();
-            $this->close();
             throw new Exception\CurlOptionException("Set option failed ! (error: $error)", $errno);
         }
 

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -89,7 +89,6 @@ class HttpClient implements ClientInterface
                 $errno = $curl->getErrorNumber();
 
                 //~ Close connection & stream
-                $curl->close();
                 fclose($streamResource);
 
                 throw new HttpClientException(
@@ -102,8 +101,6 @@ class HttpClient implements ClientInterface
                     $errno,
                 );
             }
-
-            $curl->close();
 
             // Create stream & move pointer after header position in "stream".
             $stream = $this->httpFactory->createStreamFromResource($streamResource);


### PR DESCRIPTION
- Add PHP 8.5 support
- Drop PHP 7.4 support
- Drop PHP 8.1 support
- Drop PHP 8.2 support
- Use PER Code Style 3.0
- Update CI config
- Deprecated usage for Curl::close() (no effect since PHP 8.0)